### PR TITLE
Add support for robots.txt file in the app root

### DIFF
--- a/python2.7-alpine3.7/entrypoint.sh
+++ b/python2.7-alpine3.7/entrypoint.sh
@@ -33,6 +33,9 @@ echo "server {
     }
     location $USE_STATIC_URL {
         alias $USE_STATIC_PATH;
+    }
+    location = /robots.txt {
+        alias /app/robots.txt
     }" > /etc/nginx/conf.d/nginx.conf
 
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)

--- a/python2.7/entrypoint.sh
+++ b/python2.7/entrypoint.sh
@@ -29,7 +29,11 @@ echo "server {
     }
     location $USE_STATIC_URL {
         alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
+    }
+    location = /robots.txt {
+        alias /app/robots.txt
+    }
+    " > /etc/nginx/conf.d/nginx.conf
 
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then 

--- a/python3.5/entrypoint.sh
+++ b/python3.5/entrypoint.sh
@@ -29,6 +29,9 @@ echo "server {
     }
     location $USE_STATIC_URL {
         alias $USE_STATIC_PATH;
+    }
+    location = /robots.txt {
+        alias /app/robots.txt
     }" > /etc/nginx/conf.d/nginx.conf
 
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)

--- a/python3.6-alpine3.7/entrypoint.sh
+++ b/python3.6-alpine3.7/entrypoint.sh
@@ -33,6 +33,9 @@ echo "server {
     }
     location $USE_STATIC_URL {
         alias $USE_STATIC_PATH;
+    }
+    location = /robots.txt {
+        alias /app/robots.txt
     }" > /etc/nginx/conf.d/nginx.conf
 
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -29,6 +29,9 @@ echo "server {
     }
     location $USE_STATIC_URL {
         alias $USE_STATIC_PATH;
+    }
+    location = /robots.txt {
+        alias /app/robots.txt
     }" > /etc/nginx/conf.d/nginx.conf
 
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)


### PR DESCRIPTION
I found this image to be missing support for `robots.txt` files, which should typically be located at the root. This PR adds a simple alias route that points `/robots.txt` to `/app/robots.txt`.

While this is a simple fix to this specific problem, I do believe being able to have Nginx serve arbitrary static files from the root is a feature that would be nice to have.