### PR TITLE
Fix the readme typo in the quickstart SPAs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ COPY ./app /app
 * Create a `main.py` file (it should be named like that and should be in your `app` directory) with:
 
 ```python
+import os
 from flask import Flask, send_file
 app = Flask(__name__)
 


### PR DESCRIPTION
This fixes #90 by adding `import os` in the quickstart SPAs section.