### PR TITLE
Fix the version misspelling from #106

### DIFF
--- a/example-flask-python3.7-index/docker-compose.yml
+++ b/example-flask-python3.7-index/docker-compose.yml
@@ -1,4 +1,4 @@
-version: 3'
+version: '3'
 services:
   web:
     build: ./


### PR DESCRIPTION
This PR fixes https://github.com/tiangolo/uwsgi-nginx-flask-docker/issues/106, but to fix it entirely it still needs an update to the already released zip (as mentioned over in https://github.com/tiangolo/uwsgi-nginx-flask-docker/issues/106#issuecomment-438858074).