### PR TITLE
Generate Nginx configs from entrypoint

### DIFF
--- a/python2.7-alpine3.7/Dockerfile
+++ b/python2.7-alpine3.7/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python2.7-alpine3.7/entrypoint.sh
+++ b/python2.7-alpine3.7/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,31 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
-# Otherwise uWSGI can't import Flask
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages:/usr/lib/python2.7/site-packages
-
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python2.7-alpine3.7/entrypoint.sh
+++ b/python2.7-alpine3.7/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 /uwsgi-nginx-entrypoint.sh
 
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages:/usr/lib/python2.7/site-packages
+
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
 # Get the absolute path of the static files from the environment variable
@@ -23,7 +27,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python2.7-alpine3.8/Dockerfile
+++ b/python2.7-alpine3.8/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python2.7-alpine3.8/entrypoint.sh
+++ b/python2.7-alpine3.8/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,31 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
-# Otherwise uWSGI can't import Flask
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages:/usr/lib/python2.7/site-packages
-
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python2.7-alpine3.8/entrypoint.sh
+++ b/python2.7-alpine3.8/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 /uwsgi-nginx-entrypoint.sh
 
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages:/usr/lib/python2.7/site-packages
+
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
 # Get the absolute path of the static files from the environment variable
@@ -23,7 +27,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python2.7/Dockerfile
+++ b/python2.7/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python2.7/entrypoint.sh
+++ b/python2.7/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env bash
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [[ -v NGINX_WORKER_CONNECTIONS ]] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [[ -v NGINX_WORKER_OPEN_FILES ]] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,27 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then 
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+if [[ $STATIC_INDEX == 1 ]] ; then
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python2.7/entrypoint.sh
+++ b/python2.7/entrypoint.sh
@@ -23,7 +23,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.5/Dockerfile
+++ b/python3.5/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.5/entrypoint.sh
+++ b/python3.5/entrypoint.sh
@@ -23,7 +23,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.5/entrypoint.sh
+++ b/python3.5/entrypoint.sh
@@ -1,25 +1,7 @@
-#! /usr/bin/env bash
+#! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [[ -v NGINX_WORKER_CONNECTIONS ]] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [[ -v NGINX_WORKER_OPEN_FILES ]] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,27 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then 
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+if [[ $STATIC_INDEX == 1 ]] ; then
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.6-alpine3.7/Dockerfile
+++ b/python3.6-alpine3.7/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.6-alpine3.7/entrypoint.sh
+++ b/python3.6-alpine3.7/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,31 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
-# Otherwise uWSGI can't import Flask
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
-
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.6-alpine3.7/entrypoint.sh
+++ b/python3.6-alpine3.7/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 /uwsgi-nginx-entrypoint.sh
 
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
+
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
 # Get the absolute path of the static files from the environment variable
@@ -23,7 +27,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.6-alpine3.8/Dockerfile
+++ b/python3.6-alpine3.8/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.6-alpine3.8/entrypoint.sh
+++ b/python3.6-alpine3.8/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,31 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
-# Otherwise uWSGI can't import Flask
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
-
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.6-alpine3.8/entrypoint.sh
+++ b/python3.6-alpine3.8/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 /uwsgi-nginx-entrypoint.sh
 
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
+
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
 # Get the absolute path of the static files from the environment variable
@@ -23,7 +27,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env bash
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [[ -v NGINX_WORKER_CONNECTIONS ]] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [[ -v NGINX_WORKER_OPEN_FILES ]] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,27 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then 
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+if [[ $STATIC_INDEX == 1 ]] ; then
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.6/entrypoint.sh
+++ b/python3.6/entrypoint.sh
@@ -23,7 +23,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.7-alpine3.7/Dockerfile
+++ b/python3.7-alpine3.7/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.7-alpine3.7/entrypoint.sh
+++ b/python3.7-alpine3.7/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 /uwsgi-nginx-entrypoint.sh
 
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.7/site-packages:/usr/lib/python3.7/site-packages
+
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
 # Get the absolute path of the static files from the environment variable
@@ -23,7 +27,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.7-alpine3.7/entrypoint.sh
+++ b/python3.7-alpine3.7/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,31 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
-# Otherwise uWSGI can't import Flask
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.7/site-packages:/usr/lib/python3.7/site-packages
-
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.7-alpine3.8/Dockerfile
+++ b/python3.7-alpine3.8/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.7-alpine3.8/entrypoint.sh
+++ b/python3.7-alpine3.8/entrypoint.sh
@@ -3,6 +3,10 @@ set -e
 
 /uwsgi-nginx-entrypoint.sh
 
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.7/site-packages:/usr/lib/python3.7/site-packages
+
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
 # Get the absolute path of the static files from the environment variable
@@ -23,7 +27,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/python3.7-alpine3.8/entrypoint.sh
+++ b/python3.7-alpine3.8/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env sh
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,31 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
-# Otherwise uWSGI can't import Flask
-export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.7/site-packages:/usr/lib/python3.7/site-packages
-
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
 if [[ $STATIC_INDEX == 1 ]] ; then
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -4,19 +4,6 @@ LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
 RUN pip install flask
 
-# By default, allow unlimited file sizes, modify it to limit the file sizes
-# To have a maximum of 1 MB (Nginx's default) change the line to:
-# ENV NGINX_MAX_UPLOAD 1m
-ENV NGINX_MAX_UPLOAD 0
-
-# By default, Nginx listens on port 80.
-# To modify this, change LISTEN_PORT environment variable.
-# (in a Dockerfile or with an option for `docker run`)
-ENV LISTEN_PORT 80
-
-# Which uWSGI .ini file should be used, to make it customizable
-ENV UWSGI_INI /app/uwsgi.ini
-
 # URL under which static (not modified by Python) files will be requested
 # They will be served by Nginx directly, without being handled by uWSGI
 ENV STATIC_URL /static
@@ -38,6 +25,8 @@ ENV PYTHONPATH=/app
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
 # Copy the entrypoint that will generate Nginx additional configs
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/python3.7/entrypoint.sh
+++ b/python3.7/entrypoint.sh
@@ -1,25 +1,7 @@
 #! /usr/bin/env bash
 set -e
-# Get the maximum upload file size for Nginx, default to 0: unlimited
-USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
-# Generate Nginx config for maximum upload file size
-echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
 
-# Get the number of workers for Nginx, default to 1
-USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
-# Modify the number of worker processes in Nginx config
-sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
-
-# Set the max number of connections per worker for Nginx, if requested
-# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
-if [[ -v NGINX_WORKER_CONNECTIONS ]] ; then
-    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
-fi
-
-# Set the max number of open file descriptors for Nginx workers, if requested
-if [[ -v NGINX_WORKER_OPEN_FILES ]] ; then
-    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
-fi
+/uwsgi-nginx-entrypoint.sh
 
 # Get the URL for static files from the environment variable
 USE_STATIC_URL=${STATIC_URL:-'/static'}
@@ -28,27 +10,26 @@ USE_STATIC_PATH=${STATIC_PATH:-'/app/static'}
 # Get the listen port for Nginx, default to 80
 USE_LISTEN_PORT=${LISTEN_PORT:-80}
 
-# Generate Nginx config first part using the environment variables
-echo "server {
-    listen ${USE_LISTEN_PORT};
-    location / {
-        try_files \$uri @app;
-    }
-    location @app {
-        include uwsgi_params;
-        uwsgi_pass unix:///tmp/uwsgi.sock;
-    }
-    location $USE_STATIC_URL {
-        alias $USE_STATIC_PATH;
-    }" > /etc/nginx/conf.d/nginx.conf
-
+content_server='server {\n'
+content_server=$content_server"    listen ${USE_LISTEN_PORT};\n"
+content_server=$content_server'    location / {\n'
+content_server=$content_server'        try_files $uri @app;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server'    location @app {\n'
+content_server=$content_server'        include uwsgi_params;\n'
+content_server=$content_server'        uwsgi_pass unix:///tmp/uwsgi.sock;\n'
+content_server=$content_server'    }\n'
+content_server=$content_server"    location $USE_STATIC_URL {\n"
+content_server=$content_server"        alias $USE_STATIC_PATH;\n"
+content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then 
-echo "    location = / {
-        index $USE_STATIC_URL/index.html;
-    }" >> /etc/nginx/conf.d/nginx.conf
+if [[ $STATIC_INDEX == 1 ]] ; then
+    content_server=$content_server'    location = / {\n'
+    content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
+    content_server=$content_server'    }\n'
 fi
-# Finish the Nginx config file
-echo "}" >> /etc/nginx/conf.d/nginx.conf
+content_server=$content_server'}\n'
+# Save generated server /etc/nginx/conf.d/nginx.conf
+printf "$content_server" > /etc/nginx/conf.d/nginx.conf
 
 exec "$@"

--- a/python3.7/entrypoint.sh
+++ b/python3.7/entrypoint.sh
@@ -23,7 +23,7 @@ content_server=$content_server"    location $USE_STATIC_URL {\n"
 content_server=$content_server"        alias $USE_STATIC_PATH;\n"
 content_server=$content_server'    }\n'
 # If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
-if [[ $STATIC_INDEX == 1 ]] ; then
+if [ "$STATIC_INDEX" = 1 ] ; then
     content_server=$content_server'    location = / {\n'
     content_server=$content_server"        index $USE_STATIC_URL/index.html;\n"
     content_server=$content_server'    }\n'

--- a/tests/test_01_main/test_defaults_01.py
+++ b/tests/test_01_main/test_defaults_01.py
@@ -3,11 +3,66 @@ import time
 import docker
 import pytest
 import requests
-from requests import Response
 
-from ..utils import CONTAINER_NAME, get_logs, get_nginx_config, stop_previous_container
+from ..utils import (
+    CONTAINER_NAME,
+    get_logs,
+    get_nginx_config,
+    remove_previous_container,
+)
 
 client = docker.from_env()
+
+
+def verify_container(container, response_text):
+    nginx_config = get_nginx_config(container)
+    assert "client_max_body_size 0;" in nginx_config
+    assert "worker_processes 1;" in nginx_config
+    assert "listen 80;" in nginx_config
+    assert "worker_connections 1024;" in nginx_config
+    assert "worker_rlimit_nofile;" not in nginx_config
+    assert "daemon off;" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
+    assert "try_files $uri @app;" in nginx_config
+    assert "location @app {" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "location /static {" in nginx_config
+    assert "alias /app/static;" in nginx_config
+    # Nginx index.html specific
+    assert "location = / {" not in nginx_config
+    assert "index /static/index.html;" not in nginx_config
+    logs = get_logs(container)
+    assert "getting INI configuration from /app/uwsgi.ini" in logs
+    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
+    assert "ini = /app/uwsgi.ini" in logs
+    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
+    assert "socket = /tmp/uwsgi.sock" in logs
+    assert "chown-socket = nginx:nginx" in logs
+    assert "chmod-socket = 664" in logs
+    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
+    assert "need-app = true" in logs
+    assert "die-on-term = true" in logs
+    assert "show-config = true" in logs
+    assert "module = main" in logs
+    assert "callable = app" in logs
+    assert "processes = 16" in logs
+    assert "cheaper = 2" in logs
+    assert "Checking for script in /app/prestart.sh" in logs
+    assert "Running script /app/prestart.sh" in logs
+    assert (
+        "Running inside /app/prestart.sh, you could add migrations to this file" in logs
+    )
+    assert "spawned uWSGI master process" in logs
+    assert "spawned uWSGI worker 1" in logs
+    assert "spawned uWSGI worker 2" in logs
+    assert "spawned uWSGI worker 3" not in logs
+    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
+    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
+    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
+    response = requests.get("http://127.0.0.1:8000")
+    assert response.status_code == 200
+    assert response.text == response_text
 
 
 @pytest.mark.parametrize(
@@ -56,58 +111,16 @@ client = docker.from_env()
     ],
 )
 def test_defaults(image, response_text):
-    stop_previous_container(client)
+    remove_previous_container(client)
     container = client.containers.run(
         image, name=CONTAINER_NAME, ports={"80": "8000"}, detach=True
     )
-    nginx_config = get_nginx_config(container)
-    assert "client_max_body_size 0;" in nginx_config
-    assert "worker_processes 1;" in nginx_config
-    assert "listen 80;" in nginx_config
-    assert "worker_connections  1024;" in nginx_config
-    assert "worker_rlimit_nofile;" not in nginx_config
-    assert "daemon off;" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
-    assert "try_files $uri @app;" in nginx_config
-    assert "location @app {" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "location /static {" in nginx_config
-    assert "alias /app/static;" in nginx_config
-    # Nginx index.html specific
-    assert "location = / {" not in nginx_config
-    assert "index /static/index.html;" not in nginx_config
+    time.sleep(5)
+    verify_container(container, response_text)
+    container.stop()
+    # Test that everything works after restarting too
+    container.start()
     time.sleep(3)
-    logs = get_logs(container)
-    assert "getting INI configuration from /app/uwsgi.ini" in logs
-    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
-    assert "ini = /app/uwsgi.ini" in logs
-    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
-    assert "socket = /tmp/uwsgi.sock" in logs
-    assert "chown-socket = nginx:nginx" in logs
-    assert "chmod-socket = 664" in logs
-    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
-    assert "need-app = true" in logs
-    assert "die-on-term = true" in logs
-    assert "show-config = true" in logs
-    assert "module = main" in logs
-    assert "callable = app" in logs
-    assert "processes = 16" in logs
-    assert "cheaper = 2" in logs
-    assert "Checking for script in /app/prestart.sh" in logs
-    assert "Running script /app/prestart.sh" in logs
-    assert (
-        "Running inside /app/prestart.sh, you could add migrations to this file" in logs
-    )
-    assert "spawned uWSGI master process" in logs
-    assert "spawned uWSGI worker 1" in logs
-    assert "spawned uWSGI worker 2" in logs
-    assert "spawned uWSGI worker 3" not in logs
-    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
-    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
-    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
-    response: Response = requests.get("http://127.0.0.1:8000")
-    assert response.status_code == 200
-    assert response.text == response_text
+    verify_container(container, response_text)
     container.stop()
     container.remove()

--- a/tests/test_01_main/test_env_vars_03.py
+++ b/tests/test_01_main/test_env_vars_03.py
@@ -5,9 +5,67 @@ import pytest
 import requests
 from requests import Response
 
-from ..utils import CONTAINER_NAME, get_logs, get_nginx_config, stop_previous_container
+from ..utils import (
+    CONTAINER_NAME,
+    get_logs,
+    get_nginx_config,
+    remove_previous_container,
+)
 
 client = docker.from_env()
+
+
+def verify_container(container, response_text):
+    nginx_config = get_nginx_config(container)
+    assert "client_max_body_size 1m;" in nginx_config
+    assert "worker_processes 2;" in nginx_config
+    assert "listen 80;" in nginx_config
+    assert "worker_connections 2048;" in nginx_config
+    assert "worker_rlimit_nofile 2048;" in nginx_config
+    assert "daemon off;" in nginx_config
+    assert "listen 80;" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
+    assert "try_files $uri @app;" in nginx_config
+    assert "location @app {" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "location /static {" in nginx_config
+    assert "alias /app/static;" in nginx_config
+    # Nginx index.html specific
+    assert "location = / {" not in nginx_config
+    assert "index /static/index.html;" not in nginx_config
+    logs = get_logs(container)
+    assert "getting INI configuration from /app/uwsgi.ini" in logs
+    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
+    assert "ini = /app/uwsgi.ini" in logs
+    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
+    assert "socket = /tmp/uwsgi.sock" in logs
+    assert "chown-socket = nginx:nginx" in logs
+    assert "chmod-socket = 664" in logs
+    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
+    assert "need-app = true" in logs
+    assert "die-on-term = true" in logs
+    assert "show-config = true" in logs
+    assert "module = main" in logs
+    assert "callable = app" in logs
+    assert "processes = 8" in logs
+    assert "cheaper = 3" in logs
+    assert "spawned uWSGI master process" in logs
+    assert "spawned uWSGI worker 1" in logs
+    assert "spawned uWSGI worker 2" in logs
+    assert "spawned uWSGI worker 3" in logs
+    assert "spawned uWSGI worker 4" not in logs
+    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
+    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
+    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
+    assert "Checking for script in /app/prestart.sh" in logs
+    assert "Running script /app/prestart.sh" in logs
+    assert (
+        "Running inside /app/prestart.sh, you could add migrations to this file" in logs
+    )
+    response: Response = requests.get("http://127.0.0.1:8000")
+    assert response.status_code == 200
+    assert response.text == response_text
 
 
 @pytest.mark.parametrize(
@@ -56,7 +114,7 @@ client = docker.from_env()
     ],
 )
 def test_defaults(image, response_text):
-    stop_previous_container(client)
+    remove_previous_container(client)
     container = client.containers.run(
         image,
         name=CONTAINER_NAME,
@@ -71,56 +129,12 @@ def test_defaults(image, response_text):
         ports={"80": "8000"},
         detach=True,
     )
-    nginx_config = get_nginx_config(container)
-    assert "client_max_body_size 1m;" in nginx_config
-    assert "worker_processes 2;" in nginx_config
-    assert "listen 80;" in nginx_config
-    assert "worker_connections 2048;" in nginx_config
-    assert "worker_rlimit_nofile 2048;" in nginx_config
-    assert "daemon off;" in nginx_config
-    assert "listen 80;" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
-    assert "try_files $uri @app;" in nginx_config
-    assert "location @app {" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "location /static {" in nginx_config
-    assert "alias /app/static;" in nginx_config
-    # Nginx index.html specific
-    assert "location = / {" not in nginx_config
-    assert "index /static/index.html;" not in nginx_config
     time.sleep(3)
-    logs = get_logs(container)
-    assert "getting INI configuration from /app/uwsgi.ini" in logs
-    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
-    assert "ini = /app/uwsgi.ini" in logs
-    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
-    assert "socket = /tmp/uwsgi.sock" in logs
-    assert "chown-socket = nginx:nginx" in logs
-    assert "chmod-socket = 664" in logs
-    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
-    assert "need-app = true" in logs
-    assert "die-on-term = true" in logs
-    assert "show-config = true" in logs
-    assert "module = main" in logs
-    assert "callable = app" in logs
-    assert "processes = 8" in logs
-    assert "cheaper = 3" in logs
-    assert "spawned uWSGI master process" in logs
-    assert "spawned uWSGI worker 1" in logs
-    assert "spawned uWSGI worker 2" in logs
-    assert "spawned uWSGI worker 3" in logs
-    assert "spawned uWSGI worker 4" not in logs
-    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
-    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
-    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
-    assert "Checking for script in /app/prestart.sh" in logs
-    assert "Running script /app/prestart.sh" in logs
-    assert (
-        "Running inside /app/prestart.sh, you could add migrations to this file" in logs
-    )
-    response: Response = requests.get("http://127.0.0.1:8000")
-    assert response.status_code == 200
-    assert response.text == response_text
+    verify_container(container, response_text)
+    container.stop()
+    # Test that everything works after restarting too
+    container.start()
+    time.sleep(3)
+    verify_container(container, response_text)
     container.stop()
     container.remove()

--- a/tests/test_02_app/test_app_and_env_vars.py
+++ b/tests/test_02_app/test_app_and_env_vars.py
@@ -5,9 +5,68 @@ import docker
 import pytest
 import requests
 
-from ..utils import CONTAINER_NAME, get_logs, get_nginx_config, stop_previous_container
+from ..utils import (
+    CONTAINER_NAME,
+    get_logs,
+    get_nginx_config,
+    remove_previous_container,
+)
 
 client = docker.from_env()
+
+
+def verify_container(container, response_text):
+    nginx_config = get_nginx_config(container)
+    assert "client_max_body_size 0;" in nginx_config
+    assert "worker_processes 1;" in nginx_config
+    assert "listen 8080;" in nginx_config
+    assert "worker_connections 1024;" in nginx_config
+    assert "worker_rlimit_nofile;" not in nginx_config
+    assert "daemon off;" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
+    # Nginx index.html specific
+    assert "location /content {" in nginx_config
+    assert "index /content/index.html;" in nginx_config
+    assert "location = / {" in nginx_config
+    assert "alias /application/custom_app/content;" in nginx_config
+    logs = get_logs(container)
+    assert "getting INI configuration from /application/custom_app/uwsgi.ini" in logs
+    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
+    assert "ini = /application/custom_app/uwsgi.ini" in logs
+    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
+    assert "socket = /tmp/uwsgi.sock" in logs
+    assert "chown-socket = nginx:nginx" in logs
+    assert "chmod-socket = 664" in logs
+    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
+    assert "need-app = true" in logs
+    assert "die-on-term = true" in logs
+    assert "show-config = true" in logs
+    assert "module = custom_app.main" in logs
+    assert "callable = custom_app" in logs
+    assert "processes = 16" in logs
+    assert "cheaper = 2" in logs
+    assert "Checking for script in /app/prestart.sh" in logs
+    assert "Running script /app/prestart.sh" in logs
+    assert "custom prestart.sh running" in logs
+    assert "spawned uWSGI master process" in logs
+    assert "spawned uWSGI worker 1" in logs
+    assert "spawned uWSGI worker 2" in logs
+    assert "spawned uWSGI worker 3" not in logs
+    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
+    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
+    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
+    response = requests.get("http://127.0.0.1:8000")
+    assert response.status_code == 200
+    assert (
+        response.text == "<html><body><h1>Hello World from HTML test</h1></body></html>"
+    )
+    response = requests.get("http://127.0.0.1:8000/api")
+    assert response.status_code == 200
+    assert response.text == response_text
+    response = requests.get("http://127.0.0.1:8000/content/test.txt")
+    assert response.status_code == 200
+    assert response.text == "Static test"
 
 
 @pytest.mark.parametrize(
@@ -60,7 +119,7 @@ client = docker.from_env()
     ],
 )
 def test_env_vars_1(dockerfile, response_text):
-    stop_previous_container(client)
+    remove_previous_container(client)
     tag = "uwsgi-nginx-flask-testimage"
     test_path: PurePath = Path(__file__)
     path = test_path.parent / "custom_app"
@@ -78,57 +137,12 @@ def test_env_vars_1(dockerfile, response_text):
         ports={"8080": "8000"},
         detach=True,
     )
-    nginx_config = get_nginx_config(container)
-    assert "client_max_body_size 0;" in nginx_config
-    assert "worker_processes 1;" in nginx_config
-    assert "listen 8080;" in nginx_config
-    assert "worker_connections  1024;" in nginx_config
-    assert "worker_rlimit_nofile;" not in nginx_config
-    assert "daemon off;" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
-    # Nginx index.html specific
-    assert "location /content {" in nginx_config
-    assert "index /content/index.html;" in nginx_config
-    assert "location = / {" in nginx_config
-    assert "alias /application/custom_app/content;" in nginx_config
     time.sleep(5)
-    logs = get_logs(container)
-    assert "getting INI configuration from /application/custom_app/uwsgi.ini" in logs
-    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
-    assert "ini = /application/custom_app/uwsgi.ini" in logs
-    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
-    assert "socket = /tmp/uwsgi.sock" in logs
-    assert "chown-socket = nginx:nginx" in logs
-    assert "chmod-socket = 664" in logs
-    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
-    assert "need-app = true" in logs
-    assert "die-on-term = true" in logs
-    assert "show-config = true" in logs
-    assert "module = custom_app.main" in logs
-    assert "callable = custom_app" in logs
-    assert "processes = 16" in logs
-    assert "cheaper = 2" in logs
-    assert "Checking for script in /app/prestart.sh" in logs
-    assert "Running script /app/prestart.sh" in logs
-    assert "custom prestart.sh running" in logs
-    assert "spawned uWSGI master process" in logs
-    assert "spawned uWSGI worker 1" in logs
-    assert "spawned uWSGI worker 2" in logs
-    assert "spawned uWSGI worker 3" not in logs
-    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
-    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
-    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
-    response: Response = requests.get("http://127.0.0.1:8000")
-    assert response.status_code == 200
-    assert (
-        response.text == "<html><body><h1>Hello World from HTML test</h1></body></html>"
-    )
-    response: Response = requests.get("http://127.0.0.1:8000/api")
-    assert response.status_code == 200
-    assert response.text == response_text
-    response: Response = requests.get("http://127.0.0.1:8000/content/test.txt")
-    assert response.status_code == 200
-    assert response.text == "Static test"
+    verify_container(container, response_text)
+    container.stop()
+    # Test that everything works after restarting too
+    container.start()
+    time.sleep(3)
+    verify_container(container, response_text)
     container.stop()
     container.remove()

--- a/tests/test_02_app/test_simple_app.py
+++ b/tests/test_02_app/test_simple_app.py
@@ -5,9 +5,68 @@ import docker
 import pytest
 import requests
 
-from ..utils import CONTAINER_NAME, get_logs, get_nginx_config, stop_previous_container
+from ..utils import (
+    CONTAINER_NAME,
+    get_logs,
+    get_nginx_config,
+    remove_previous_container,
+)
 
 client = docker.from_env()
+
+
+def verify_container(container, response_text):
+    nginx_config = get_nginx_config(container)
+    assert "client_max_body_size 0;" in nginx_config
+    assert "worker_processes 1;" in nginx_config
+    assert "listen 80;" in nginx_config
+    assert "worker_connections 1024;" in nginx_config
+    assert "worker_rlimit_nofile;" not in nginx_config
+    assert "daemon off;" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
+    assert "try_files $uri @app;" in nginx_config
+    assert "location @app {" in nginx_config
+    assert "include uwsgi_params;" in nginx_config
+    assert "location /static {" in nginx_config
+    assert "alias /app/static;" in nginx_config
+    # Nginx index.html specific
+    assert "location = / {" not in nginx_config
+    assert "index /static/index.html;" not in nginx_config
+    logs = get_logs(container)
+    assert "getting INI configuration from /app/uwsgi.ini" in logs
+    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
+    assert "ini = /app/uwsgi.ini" in logs
+    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
+    assert "socket = /tmp/uwsgi.sock" in logs
+    assert "chown-socket = nginx:nginx" in logs
+    assert "chmod-socket = 664" in logs
+    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
+    assert "need-app = true" in logs
+    assert "die-on-term = true" in logs
+    assert "show-config = true" in logs
+    assert "module = main" in logs
+    assert "callable = app" in logs
+    assert "processes = 16" in logs
+    assert "cheaper = 2" in logs
+    assert "Checking for script in /app/prestart.sh" in logs
+    assert "Running script /app/prestart.sh" in logs
+    assert (
+        "Running inside /app/prestart.sh, you could add migrations to this file" in logs
+    )
+    assert "spawned uWSGI master process" in logs
+    assert "spawned uWSGI worker 1" in logs
+    assert "spawned uWSGI worker 2" in logs
+    assert "spawned uWSGI worker 3" not in logs
+    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
+    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
+    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
+    response = requests.get("http://127.0.0.1:8000")
+    assert response.status_code == 200
+    assert response.text == response_text
+    response = requests.get("http://127.0.0.1:8000/static/test.txt")
+    assert response.status_code == 200
+    assert response.text == "Static test"
 
 
 @pytest.mark.parametrize(
@@ -60,7 +119,7 @@ client = docker.from_env()
     ],
 )
 def test_env_vars_1(dockerfile, response_text):
-    stop_previous_container(client)
+    remove_previous_container(client)
     tag = "uwsgi-nginx-flask-testimage"
     test_path: PurePath = Path(__file__)
     path = test_path.parent / "simple_app"
@@ -68,57 +127,12 @@ def test_env_vars_1(dockerfile, response_text):
     container = client.containers.run(
         tag, name=CONTAINER_NAME, ports={"80": "8000"}, detach=True
     )
-    nginx_config = get_nginx_config(container)
-    assert "client_max_body_size 0;" in nginx_config
-    assert "worker_processes 1;" in nginx_config
-    assert "listen 80;" in nginx_config
-    assert "worker_connections  1024;" in nginx_config
-    assert "worker_rlimit_nofile;" not in nginx_config
-    assert "daemon off;" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "uwsgi_pass unix:///tmp/uwsgi.sock;" in nginx_config
-    assert "try_files $uri @app;" in nginx_config
-    assert "location @app {" in nginx_config
-    assert "include uwsgi_params;" in nginx_config
-    assert "location /static {" in nginx_config
-    assert "alias /app/static;" in nginx_config
-    # Nginx index.html specific
-    assert "location = / {" not in nginx_config
-    assert "index /static/index.html;" not in nginx_config
     time.sleep(5)
-    logs = get_logs(container)
-    assert "getting INI configuration from /app/uwsgi.ini" in logs
-    assert "getting INI configuration from /etc/uwsgi/uwsgi.ini" in logs
-    assert "ini = /app/uwsgi.ini" in logs
-    assert "ini = /etc/uwsgi/uwsgi.ini" in logs
-    assert "socket = /tmp/uwsgi.sock" in logs
-    assert "chown-socket = nginx:nginx" in logs
-    assert "chmod-socket = 664" in logs
-    assert "hook-master-start = unix_signal:15 gracefully_kill_them_all" in logs
-    assert "need-app = true" in logs
-    assert "die-on-term = true" in logs
-    assert "show-config = true" in logs
-    assert "module = main" in logs
-    assert "callable = app" in logs
-    assert "processes = 16" in logs
-    assert "cheaper = 2" in logs
-    assert "Checking for script in /app/prestart.sh" in logs
-    assert "Running script /app/prestart.sh" in logs
-    assert (
-        "Running inside /app/prestart.sh, you could add migrations to this file" in logs
-    )
-    assert "spawned uWSGI master process" in logs
-    assert "spawned uWSGI worker 1" in logs
-    assert "spawned uWSGI worker 2" in logs
-    assert "spawned uWSGI worker 3" not in logs
-    assert 'running "unix_signal:15 gracefully_kill_them_all" (master-start)' in logs
-    assert "success: nginx entered RUNNING state, process has stayed up for" in logs
-    assert "success: uwsgi entered RUNNING state, process has stayed up for" in logs
-    response: Response = requests.get("http://127.0.0.1:8000")
-    assert response.status_code == 200
-    assert response.text == response_text
-    response: Response = requests.get("http://127.0.0.1:8000/static/test.txt")
-    assert response.status_code == 200
-    assert response.text == "Static test"
+    verify_container(container, response_text)
+    container.stop()
+    # Test that everything works after restarting too
+    container.start()
+    time.sleep(3)
+    verify_container(container, response_text)
     container.stop()
     container.remove()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ def get_nginx_config(container):
     return result.output.decode()
 
 
-def stop_previous_container(client):
+def remove_previous_container(client):
     try:
         previous = client.containers.get(CONTAINER_NAME)
         previous.stop()


### PR DESCRIPTION
Generate Nginx configs from entrypoint instead of modifying live pre-existing files.

This is a more "purely functional" approach that improves stability, debuggability, etc.

It will also allow having a completely custom nginx.conf file to be used instead of the generated one.

It's a major refactor, but the tests ensure everything is working.

It's the first (big) step to allow having a completely custom nginx.conf, that will solve:
tiangolo/uwsgi-nginx-flask-docker#116
tiangolo/uwsgi-nginx-flask-docker#108
tiangolo/uwsgi-nginx-flask-docker#103

It depends on the PR in the parent image `uwsgi-nginx`: https://github.com/tiangolo/uwsgi-nginx-docker/pull/50