### PR TITLE
Upgrade pip before using it

### DIFF
--- a/docker-images/python2.7.dockerfile
+++ b/docker-images/python2.7.dockerfile
@@ -2,6 +2,8 @@ FROM tiangolo/uwsgi-nginx:python2.7
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN python -m pip install --upgrade pip
+
 RUN pip install flask
 
 # URL under which static (not modified by Python) files will be requested

--- a/docker-images/python3.6.dockerfile
+++ b/docker-images/python3.6.dockerfile
@@ -2,6 +2,8 @@ FROM tiangolo/uwsgi-nginx:python3.6
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN python -m pip install --upgrade pip
+
 RUN pip install flask
 
 # URL under which static (not modified by Python) files will be requested

--- a/docker-images/python3.7.dockerfile
+++ b/docker-images/python3.7.dockerfile
@@ -2,6 +2,8 @@ FROM tiangolo/uwsgi-nginx:python3.7
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN python -m pip install --upgrade pip
+
 RUN pip install flask
 
 # URL under which static (not modified by Python) files will be requested

--- a/docker-images/python3.8-alpine.dockerfile
+++ b/docker-images/python3.8-alpine.dockerfile
@@ -2,6 +2,8 @@ FROM tiangolo/uwsgi-nginx:python3.8-alpine
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN python -m pip install --upgrade pip
+
 RUN pip install flask
 
 # URL under which static (not modified by Python) files will be requested

--- a/docker-images/python3.8.dockerfile
+++ b/docker-images/python3.8.dockerfile
@@ -2,6 +2,8 @@ FROM tiangolo/uwsgi-nginx:python3.8
 
 LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
 
+RUN python -m pip install --upgrade pip
+
 RUN pip install flask
 
 # URL under which static (not modified by Python) files will be requested


### PR DESCRIPTION
upgrade pip to fix this warning:

`WARNING: You are using pip version 20.1; however, version 20.1.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
`