### PR TITLE
Draft: Added ARM64 support for Python 3.8 & 3.9

### DIFF
--- a/docker-images/python3.8-arm64.dockerfile
+++ b/docker-images/python3.8-arm64.dockerfile
@@ -1,0 +1,35 @@
+FROM tiangolo/uwsgi-nginx:python3.8-arm64
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install flask
+
+# URL under which static (not modified by Python) files will be requested
+# They will be served by Nginx directly, without being handled by uWSGI
+ENV STATIC_URL /static
+# Absolute path in where the static files wil be
+ENV STATIC_PATH /app/static
+
+# If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
+# ENV STATIC_INDEX 1
+ENV STATIC_INDEX 0
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+# Make /app/* available to be imported by Python globally to better support several use cases like Alembic migrations.
+ENV PYTHONPATH=/app
+
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Run the start script provided by the parent image tiangolo/uwsgi-nginx.
+# It will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Supervisor, which in turn will start Nginx and uWSGI
+CMD ["/start.sh"]

--- a/docker-images/python3.9-arm64.dockerfile
+++ b/docker-images/python3.9-arm64.dockerfile
@@ -1,0 +1,35 @@
+FROM tiangolo/uwsgi-nginx:python3.9-arm64
+
+LABEL maintainer="Sebastian Ramirez <tiangolo@gmail.com>"
+
+RUN pip install flask
+
+# URL under which static (not modified by Python) files will be requested
+# They will be served by Nginx directly, without being handled by uWSGI
+ENV STATIC_URL /static
+# Absolute path in where the static files wil be
+ENV STATIC_PATH /app/static
+
+# If STATIC_INDEX is 1, serve / with /static/index.html directly (or the static URL configured)
+# ENV STATIC_INDEX 1
+ENV STATIC_INDEX 0
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+# Make /app/* available to be imported by Python globally to better support several use cases like Alembic migrations.
+ENV PYTHONPATH=/app
+
+# Move the base entrypoint to reuse it
+RUN mv /entrypoint.sh /uwsgi-nginx-entrypoint.sh
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Run the start script provided by the parent image tiangolo/uwsgi-nginx.
+# It will check for an /app/prestart.sh script (e.g. for migrations)
+# And then will start Supervisor, which in turn will start Nginx and uWSGI
+CMD ["/start.sh"]

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -9,6 +9,8 @@ environments = [
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
     {"NAME": "python2.7", "PYTHON_VERSION": "2.7"},
     {"NAME": "python3.8-alpine", "PYTHON_VERSION": "3.8"},
+    {"NAME": "python3.9-arm64", "PYTHON_VERSION": "3.9"},
+    {"NAME": "python3.8-arm64", "PYTHON_VERSION": "3.8"}
 ]
 
 start_with = os.environ.get("START_WITH")


### PR DESCRIPTION
Hey,

If you accept [this PR](https://github.com/tiangolo/uwsgi-nginx-docker/pull/109) enabling ARM64 support, this PR is a neat addition for allowing to run a flask image on a RaspberryPi.

Best,
Davide