### PR TITLE
🔥 Remove support for Python 2.7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,6 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python2.7
-            python_version: "2.7"
           - name: python3.8-alpine
             python_version: "3.8"
       fail-fast: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
             python_version: "3.7"
           - name: python3.6
             python_version: "3.6"
-          - name: python2.7
-            python_version: "2.7"
           - name: python3.8-alpine
             python_version: "3.8"
       fail-fast: true

--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@
 * [`python3.8-alpine` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-flask-docker/blob/master/docker-images/python3.8-alpine.dockerfile)
 * [`python3.7`, _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-flask-docker/blob/master/docker-images/python3.7.dockerfile)
 * [`python3.6` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-flask-docker/blob/master/docker-images/python3.6.dockerfile)
+
+## Deprecated
+
+These tags are no longer supported:
+
 * [`python2.7` _(Dockerfile)_](https://github.com/tiangolo/uwsgi-nginx-flask-docker/blob/master/docker-images/python2.7.dockerfile)
+
+---
 
 **Note**: There are [tags for each build date](https://hub.docker.com/r/tiangolo/uwsgi-nginx-flask/tags). If you need to "pin" the Docker image version you use, you can select one of those tags. E.g. `tiangolo/uwsgi-nginx-flask:python3.7-2019-10-14`.
 
 # uwsgi-nginx-flask
 
-**Docker** image with **uWSGI** and **Nginx** for **Flask** web applications in **Python 3.6** and above, and **Python 2.7** running in a single container. Optionally using Alpine Linux.
+**Docker** image with **uWSGI** and **Nginx** for **Flask** web applications in **Python** running in a single container. Optionally using Alpine Linux.
 
 ## Description
 
@@ -150,9 +157,7 @@ RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 COPY ./app /app
 ```
 
-There are several image tags available for Python 3.6 and above, and Python 2.7, but for new projects you should use the latest version available.
-
-As of now, [everyone](https://www.python.org/dev/peps/pep-0373/) [should be](http://flask.pocoo.org/docs/0.12/python3/#python3-support) [using **Python 3**](https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-should-i-use-with-django). And [Python 2.7 has reached its end of life](https://www.python.org/doc/sunset-python-2/).
+There are several image tags available but for new projects you should use the latest version available.
 
 There are several template projects that you can download (as a `.zip` file) to bootstrap your project in the section "**Examples (project templates)**" above.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "uwsgi-nginx-flask-docker"
 version = "0.1.0"
-description = "Docker image with uWSGI and Nginx for Flask applications in Python 3.6 and above and Python 2.7 running in a single container. Optionally with Alpine Linux."
+description = "Docker image with uWSGI and Nginx for Flask applications in Python running in a single container. Optionally with Alpine Linux."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 license = "MIT"
 

--- a/scripts/process_all.py
+++ b/scripts/process_all.py
@@ -8,7 +8,6 @@ environments = [
     {"NAME": "python3.8", "PYTHON_VERSION": "3.8"},
     {"NAME": "python3.7", "PYTHON_VERSION": "3.7"},
     {"NAME": "python3.6", "PYTHON_VERSION": "3.6"},
-    {"NAME": "python2.7", "PYTHON_VERSION": "2.7"},
     {"NAME": "python3.8-alpine", "PYTHON_VERSION": "3.8"},
 ]
 


### PR DESCRIPTION
🔥 Remove support for Python 2.7

---

The official Python image docs no longer list Python 2.7: https://hub.docker.com/_/python

The latest version of the official Python image tag for 2.7 was pushed a year ago: https://hub.docker.com/layers/python/library/python/2.7-buster/images/sha256-de52085267e18aba7083768f283765fcd04f753aba32cc85e62a39c77670cf4b?context=explore

I deprecated support for Python 2.7 in the parent image in: https://github.com/tiangolo/uwsgi-nginx-docker/pull/123

And I have no particular interest in supporting Python 2.7 (I don't use it, for several years ago).